### PR TITLE
Pattern route

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ rubocop --auto-correct-all
 
 ## Instructions for use
 
-This project is a back end server serving JSON data from the Yarn search from the Ravelry API.
+This project is a back end server serving JSON data from the Yarn and Pattern search from the Ravelry API.
 
-To query the API, use this route:
+To query the API for yarns, use this route:
 
 `http://127.0.0.1:3000/api/yarns.json?query={QUERY GOES HERE}`
+
+To query the API for patterns, use this route:
+
+`http://127.0.0.1:3000/api/patterns.json?query={QUERY GOES HERE}`
 
 The intended use is with [the Vue front end](https://github.com/graceolivia/yarn-detective-8-front-end).'
 

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ To query the API, use this route:
 
 `http://127.0.0.1:3000/api/yarns.json?query={QUERY GOES HERE}`
 
-The intended use is with [the Vue front end](https://github.com/graceolivia/yarn-detective-8-front-end).
+The intended use is with [the Vue front end](https://github.com/graceolivia/yarn-detective-8-front-end).'
+
+Important note: The back end needs to run on port 3000 for the front end to be able to interact with it.

--- a/app/controllers/api/patterns_controller.rb
+++ b/app/controllers/api/patterns_controller.rb
@@ -1,0 +1,12 @@
+module Api
+    class PatternsController < ApplicationController
+      include HTTParty
+      def show
+        httparty = Api::HttpartyWrapper.new
+        ravelry_query = Api::RavelryQuery.new('patterns', httparty)
+        query = params[:query]
+        rsearch = ravelry_query.search(query)
+        render json: rsearch
+      end
+    end
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Rails.application.routes.draw do
     resource :yarns do
       resource :yarns
     end
+    resource :patterns do
+      resource :patterns
+    end
   end
 end

--- a/test/controllers/api/patterns_controller_test.rb
+++ b/test/controllers/api/patterns_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+module Api
+  class PatternsControllerTest < ActionDispatch::IntegrationTest
+    test 'patterns route should render response' do
+      get '/api/patterns/'
+      assert_response :success
+    end
+
+    test 'should render page for a string search' do
+      get '/api/patterns.json?query=cascade'
+      assert_response :success
+    end
+
+    test 'should render page for a blank search' do
+      get '/api/patterns.json?query='
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
Add /patterns route which allows queries to the pattern API at Ravelry.